### PR TITLE
Check dbal version and load correct dialog helper

### DIFF
--- a/src/DoctrineMigrationsModule/Module.php
+++ b/src/DoctrineMigrationsModule/Module.php
@@ -41,10 +41,10 @@ class Module implements ConfigProviderInterface, InitProviderInterface
         );
         $cli->addCommands(array_map(array($this->serviceManager, 'get'), $commands));
         $helperSet     = $cli->getHelperSet();
-        if(Version::compare("2.5.0") == -1) {
+        if(Version::compare("2.5.0") <= 0) {
             $helperSet->set(new \Symfony\Component\Console\Helper\QuestionHelper(), 'dialog');
         } else {
-            $helperSet->set(new \Symfony\Component\Console\Helper\QuestionHelper(), 'dialog');
+            $helperSet->set(new \Symfony\Component\Console\Helper\DialogHelper(), 'dialog');
         }
 
     }


### PR DESCRIPTION
> The Dialog Helper was deprecated in Symfony 2.5 and will be removed in Symfony 3.0. You should now use the Question Helper instead, which is simpler to use.
> -[Symfony Doc](http://symfony.com/doc/current/components/console/helpers/dialoghelper.html)

If dbal version is >= 2.5.0 dialog helper is `QuestionHelper` in another case it loads DialogHelper
